### PR TITLE
fix cookie domain bug

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -283,7 +283,7 @@ profitMetricsConfig.emailInputSelector = pmEmailInputSelector;
 
 // Set Cookiedomain 
 if (pmCookieDomain){
-profitMetricsConfig.cookieDomain = pmCookieDomain.startsWith('.') ? pmCookieDomain : '.' + pmCookieDomain;
+profitMetricsConfig.cookieDomain = pmCookieDomain.indexOf('.') === 0 ? pmCookieDomain : '.' + pmCookieDomain;
 }
 
 


### PR DESCRIPTION
`startsWith` is part of ES6 spec while GTM sandboxed JS environment is based off ES5.1 spec 